### PR TITLE
Use depends_on so that wordpress doesn't have to wait for the db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,14 +13,12 @@ services:
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: password
-    # links:
-    #   - db:db
     depends_on:
       - db
   db:
     image: mysql:latest # https://hub.docker.com/_/mysql/ - or mariadb https://hub.docker.com/_/mariadb
     ports:
-      - 306:3306 # change ip if required
+      - 3306:3306 # change ip if required
     volumes:
       - ./wp-data:/docker-entrypoint-initdb.d
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   wordpress:
     image: wordpress:latest # https://hub.docker.com/_/wordpress/
     ports:
-      - 80:80 # change ip if required
+      - 127.0.0.01:80:80 # change ip if required
     volumes:
       - ./wp-app:/var/www/html # Full wordpress project
       #- ./plugin-name/trunk/:/var/www/html/wp-content/plugins/plugin-name # Plugin development
@@ -15,12 +15,19 @@ services:
       WORDPRESS_DB_PASSWORD: password
     depends_on:
       - db
+    networks:
+      - wordpress-network
   db:
     image: mysql:latest # https://hub.docker.com/_/mysql/ - or mariadb https://hub.docker.com/_/mariadb
     ports:
-      - 3306:3306 # change ip if required
+      - 127.0.0.1:3306:3306 # change ip if required
     volumes:
       - ./wp-data:/docker-entrypoint-initdb.d
     environment:
       MYSQL_DATABASE: wordpress
       MYSQL_ROOT_PASSWORD: password
+    networks:
+      - wordpress-network
+networks:
+  wordpress-network:
+      driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   wordpress:
     image: wordpress:latest # https://hub.docker.com/_/wordpress/
     ports:
-      - 127.0.10.10:80:80 # change ip if required
+      - 80:80 # change ip if required
     volumes:
       - ./wp-app:/var/www/html # Full wordpress project
       #- ./plugin-name/trunk/:/var/www/html/wp-content/plugins/plugin-name # Plugin development
@@ -13,22 +13,16 @@ services:
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: password
-    links:
-      - db:db
-    networks:
-      - wordpress-network
+    # links:
+    #   - db:db
+    depends_on:
+      - db
   db:
     image: mysql:latest # https://hub.docker.com/_/mysql/ - or mariadb https://hub.docker.com/_/mariadb
     ports:
-      - 127.0.10.10:3306:3306 # change ip if required
+      - 306:3306 # change ip if required
     volumes:
       - ./wp-data:/docker-entrypoint-initdb.d
     environment:
       MYSQL_DATABASE: wordpress
       MYSQL_ROOT_PASSWORD: password
-    networks:
-      - wordpress-network
-
-networks:
-  wordpress-network:
-      driver: bridge


### PR DESCRIPTION
Also removed the IP so that it's generic and binds to 0.0.0.0
Also removed the network as the docker compose v2 does that by default.