### PR TITLE
add support for OSX

### DIFF
--- a/config/php.conf.uploads.ini
+++ b/config/php.conf.uploads.ini
@@ -1,0 +1,6 @@
+file_uploads = On
+memory_limit = 500M
+upload_max_filesize = 30M
+post_max_size = 30M
+max_execution_time = 600
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     ports:
       - 127.0.0.1:80:80 # change ip if required
     volumes:
+      - ./config/php.conf.uploads.ini:/usr/local/etc/php/conf.d/uploads.ini
       - ./wp-app:/var/www/html # Full wordpress project
       #- ./plugin-name/trunk/:/var/www/html/wp-content/plugins/plugin-name # Plugin development
       #- ./theme-name/trunk/:/var/www/html/wp-content/themes/theme-name # Theme development

--- a/export.sh
+++ b/export.sh
@@ -1,4 +1,9 @@
+_os="`uname`"
 _now=$(date +"%m_%d_%Y")
 _file="wp-data/data_$_now.sql"
 docker-compose exec db sh -c 'exec mysqldump "$MYSQL_DATABASE" -uroot -p"$MYSQL_ROOT_PASSWORD"' > $_file
-sed -i 1,1d $_file # Removes the password warning from the file
+if [[ $_os == "Darwin"* ]] ; then
+  sed -i '.bak' 1,1d $_file
+else
+  sed -i 1,1d $_file # Removes the password warning from the file
+fi


### PR DESCRIPTION
when substituting "in place" with the -i flag using the sed in Mac OS X,
you are required to supply an extension for backing up the file.