### PR TITLE
Add custom dockerfile for wp service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: '3'
 
 services:
   wp:
-    image: wordpress:latest # https://hub.docker.com/_/wordpress/
+    build:
+      args:
+        WP_IMAGE: wordpress:latest # https://hub.docker.com/_/wordpress/
+      context: ./docker/wordpress/
     ports:
       - ${IP}:80:80 # change ip if required
     volumes:

--- a/docker/wordpress/Dockerfile
+++ b/docker/wordpress/Dockerfile
@@ -1,0 +1,4 @@
+ARG WP_IMAGE='wordpress:latest'
+FROM ${WP_IMAGE}
+
+# Include custom build code


### PR DESCRIPTION
Use a custom build to be able to extend the WordPress container used in the `wp` service.
It also allows to pass the base image of WordPress from the `docker-compose.yml` using build args.