### PR TITLE
Set correct permissions to wpcli

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
 
   wpcli:
     image: wordpress:cli
+    user: "33:33"
     volumes:
       - ./config/php.conf.ini:/usr/local/etc/php/conf.d/conf.ini
       - ./wp-app:/var/www/html


### PR DESCRIPTION
If this is not set, wpcli cannot update (as `wp core update`). 33 is the correct id for www-data user in wp.