### PR TITLE
Provide a working example with nginx-auto-ssl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,21 @@
 version: '3'
 
 services:
+  #nginx:
+    #image: valian/docker-nginx-auto-ssl:1.2.0
+    #ports:
+      #- 80:80
+      #- 443:443
+    #volumes:
+      #- ./ssl_data:/etc/resty-auto-ssl
+    #environment:
+      #ALLOWED_DOMAINS: 'yourdomain.com'
+      #SITES: 'yourdomain.com=wp:80'
+
   wp:
     image: wordpress:latest # https://hub.docker.com/_/wordpress/
     ports:
-      - ${IP}:80:80 # change ip if required
+      - ${IP}:8090:80 # change ip if required
     volumes:
       - ./config/php.conf.ini:/usr/local/etc/php/conf.d/conf.ini
       - ./wp-app:/var/www/html # Full wordpress project

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,8 @@ services:
   wp:
     image: wordpress:latest # https://hub.docker.com/_/wordpress/
     ports:
-      - ${IP}:8090:80 # change ip if required
+      - ${IP}:80:80 # change ip if required
+      #- ${IP}:8090:80 # Uncomment this if you use nginx container above
     volumes:
       - ./config/php.conf.ini:/usr/local/etc/php/conf.d/conf.ini
       - ./wp-app:/var/www/html # Full wordpress project


### PR DESCRIPTION
This PR provides an example for #48. I am not sure how you want to go with this @nezhar, so I leave them as commented lines.

To enable SSL for the WordPress site, one would need a domain (replace `yourdomain.com` with the actual domain) pointing to the server, uncomment these lines, and `docker-compose up -d`. 

Instead of going directly to the Wordpress container, HTTP/S traffic will go first to nginx container, then go to WordPress. Because of that, wp container does not need to expose via port 80 now. Otherwise, port conflict will occur.