### PR TITLE
Add support to specify a port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   wp:
     image: wordpress:latest # https://hub.docker.com/_/wordpress/
     ports:
-      - ${IP}:80:80 # change ip if required
+      - ${IP}:${PORT}:80 # change ip if required
     volumes:
       - ./config/php.conf.ini:/usr/local/etc/php/conf.d/conf.ini
       - ./wp-app:/var/www/html # Full wordpress project

--- a/env.example
+++ b/env.example
@@ -1,4 +1,4 @@
 IP=127.0.0.1
-PORT=5999
+PORT=80
 DB_ROOT_PASSWORD=password
 DB_NAME=wordpress

--- a/env.example
+++ b/env.example
@@ -1,3 +1,4 @@
 IP=127.0.0.1
+PORT=5999
 DB_ROOT_PASSWORD=password
 DB_NAME=wordpress


### PR DESCRIPTION
Add support to specify a custom port using an environment variable. Useful for using a reverse proxy for example.