### PR TITLE
Fix: authentication_plugin deprecated after 8.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,6 @@ services:
     ports:
       - ${IP}:3306:3306 # change ip if required
     command: [
-        '--default_authentication_plugin=mysql_native_password',
         '--character-set-server=utf8mb4',
         '--collation-server=utf8mb4_unicode_ci'
     ]


### PR DESCRIPTION
before this fix, on start docker compose with mysql, i have error: table.plugin doesnt exist. on stackoverfrow i find this fix