### PR TITLE
Update compose syntax for v2 cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Contents:
 
 ## Requirements
 
-Make sure you have the latest versions of **Docker** and **Docker Compose** installed on your machine.
+Make sure you have the latest versions of **Docker** and **Docker Compose** installed on your machine. The commands in this README use the Compose V2 syntax (`docker compose`), which ships with Docker Desktop and is available as the `docker-compose-plugin` package on Linux.
 
 Clone this repository or copy the files from this repository into a new folder. In the **docker-compose.yml** file you may change the IP address (in case you run multiple containers) or the database from MySQL to MariaDB.
 
@@ -38,7 +38,7 @@ Edit the `.env` file to change the default IP address, MySQL root password and W
 Open a terminal and `cd` to the folder in which `docker-compose.yml` is saved and run:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 This creates two new folders next to your `docker-compose.yml` file.
@@ -57,13 +57,13 @@ For convenience you may add a new entry into your hosts file.
 You can start the containers with the `up` command in daemon mode (by adding `-d` as an argument) or by using the `start` command:
 
 ```
-docker-compose start
+docker compose start
 ```
 
 ### Stopping containers
 
 ```
-docker-compose stop
+docker compose stop
 ```
 
 ### Removing containers
@@ -71,13 +71,13 @@ docker-compose stop
 To stop and remove all the containers use the`down` command:
 
 ```
-docker-compose down
+docker compose down
 ```
 
 Use `-v` if you need to remove the database volume which is used to persist the database:
 
 ```
-docker-compose down -v
+docker compose down -v
 ```
 
 ### Project from existing source
@@ -90,7 +90,7 @@ Copy the `docker-compose.yml` file into a new directory. In the directory you cr
 You can now use the `up` command:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 This will create the containers and populate the database with the given dump. You may set your host entry and change it in the database, or you simply overwrite it in `wp-config.php` by adding:
@@ -131,19 +131,19 @@ The docker compose configuration also provides a service for using the [WordPres
 Sample command to install WordPress:
 
 ```
-docker-compose run --rm wpcli core install --url=http://localhost --title=test --admin_user=admin --admin_email=test@example.com
+docker compose run --rm wpcli core install --url=http://localhost --title=test --admin_user=admin --admin_email=test@example.com
 ```
 
 Or to list installed plugins:
 
 ```
-docker-compose run --rm wpcli plugin list
+docker compose run --rm wpcli plugin list
 ```
 
 For an easier usage you may consider adding an alias for the CLI:
 
 ```
-alias wp="docker-compose run --rm wpcli"
+alias wp="docker compose run --rm wpcli"
 ```
 
 This way you can use the CLI command above as follows:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   wp:
     image: wordpress:latest # https://hub.docker.com/_/wordpress/
@@ -16,8 +14,6 @@ services:
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: "${DB_ROOT_PASSWORD}"
     depends_on:
-      - db
-    links:
       - db
 
   wpcli:
@@ -44,11 +40,9 @@ services:
       UPLOAD_LIMIT: 50M
     ports:
       - ${IP}:8080:80
-    links:
-      - db:db
     volumes:
-     - ./config/pma_php.ini:/usr/local/etc/php/conf.d/conf.ini
-     - ./config/pma_config.php:/etc/phpmyadmin/config.user.inc.php
+      - ./config/pma_php.ini:/usr/local/etc/php/conf.d/conf.ini
+      - ./config/pma_config.php:/etc/phpmyadmin/config.user.inc.php
 
   db:
     image: mysql:latest # https://hub.docker.com/_/mysql/ - or mariadb https://hub.docker.com/_/mariadb


### PR DESCRIPTION
This pull request updates the documentation and configuration to use Docker Compose V2 syntax and removes deprecated `links` from the `docker-compose.yml` file. These changes help modernize the setup, improve compatibility, and clarify instructions for users.